### PR TITLE
Use a template for sumo.conf

### DIFF
--- a/sumo/files/sumo.conf
+++ b/sumo/files/sumo.conf
@@ -1,4 +1,0 @@
-accessid=put yours here
-accesskey=put yours here
-#ephemeral=true
-sources=/usr/local/sumo/sumo.json

--- a/sumo/files/sumo.json
+++ b/sumo/files/sumo.json
@@ -9,7 +9,7 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "linux_auth_logs",
+            "category": "OS/Linux/Security",
             "pathExpression": "/var/log/auth.log"
         },
         {
@@ -20,7 +20,7 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "linux_package_logs",
+            "category": "OS/Linux/System",
             "pathExpression": "/var/log/apt/history.log"
         },
         {
@@ -31,7 +31,7 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "linux_package_logs",
+            "category": "OS/Linux/System",
             "pathExpression": "/var/log/dpkg.log"
         },
         {
@@ -42,7 +42,7 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "linux_service_logs",
+            "category": "OS/Linux/System",
             "pathExpression": "/var/log/syslog.log"
         }
     ]

--- a/sumo/files/sumo.json
+++ b/sumo/files/sumo.json
@@ -9,7 +9,7 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "OS/Linux/Security",
+            "category": "linux_auth_logs",
             "pathExpression": "/var/log/auth.log"
         },
         {
@@ -20,8 +20,30 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "OS/Linux/System",
+            "category": "linux_package_logs",
             "pathExpression": "/var/log/apt/history.log"
+        },
+        {
+            "name": "linux_dpkg_logs",
+            "sourceType": "LocalFile",
+            "automaticDateParsing": true,
+            "multilineProcessingEnabled": false,
+            "useAutolineMatching": true,
+            "forceTimeZone": false,
+            "timeZone": "UTC",
+            "category": "linux_package_logs",
+            "pathExpression": "/var/log/dpkg.log"
+        },
+        {
+            "name": "linux_syslog_logs",
+            "sourceType": "LocalFile",
+            "automaticDateParsing": true,
+            "multilineProcessingEnabled": false,
+            "useAutolineMatching": true,
+            "forceTimeZone": false,
+            "timeZone": "UTC",
+            "category": "linux_service_logs",
+            "pathExpression": "/var/log/syslog.log"
         }
     ]
 }

--- a/sumo/manifests/config.pp
+++ b/sumo/manifests/config.pp
@@ -1,6 +1,9 @@
 class sumo::config (
   $sumo_exec       = $sumo::params::sumo_exec,
   $sumo_short_arch = $sumo::params::sumo_short_arch,
+  $accessid        = $sumo::accessid,
+  $accesskey       = $sumo::accesskey,
+  
 ) inherits sumo::params {
 
   file {
@@ -13,7 +16,7 @@ class sumo::config (
       owner  => root,
       mode   => '0600',
       group  => root,
-      source => 'puppet:///modules/sumo/sumo.conf';
+      content => template('sumo/sumo.conf.erb');
     '/usr/local/sumo/sumo.json':
       ensure  => present,
       owner   => 'root',

--- a/sumo/manifests/init.pp
+++ b/sumo/manifests/init.pp
@@ -1,7 +1,10 @@
 class sumo (
   $sumo_exec       = $sumo::params::sumo_exec,
   $sumo_short_arch = $sumo::params::sumo_short_arch,
+  $accessid,
+  $accesskey
 ) inherits sumo::params {
 
   include sumo::config
+
 }

--- a/sumo/manifests/params.pp
+++ b/sumo/manifests/params.pp
@@ -14,6 +14,7 @@ class sumo::params {
       $sumo_short_arch = '32'
     }
     default: { fail("there is no supported arch ${::architecture}") }
+
   }
 }
 

--- a/sumo/templates/sumo.conf.erb
+++ b/sumo/templates/sumo.conf.erb
@@ -1,0 +1,4 @@
+accessid=<%= @accessid %>
+accesskey=<%= @accesskey %>
+ephemeral=true
+sources=/usr/local/sumo/sumo.json


### PR DESCRIPTION
This helps the user manage their access key without including it directly in the module. Should probably be expanded to support all the other possible entries in sumo.conf.