### PR TITLE
Get module (mostly) passing puppet-lint

### DIFF
--- a/sumo/manifests/init.pp
+++ b/sumo/manifests/init.pp
@@ -1,24 +1,25 @@
+# The official SumoLogic collector puppet module
 class sumo (
-  $sumo_exec       = $sumo::params::sumo_exec,
-  $sumo_short_arch = $sumo::params::sumo_short_arch,
-  $accessid = nil,
-  $accesskey = nil,
+  $sumo_exec             = $sumo::params::sumo_exec,
+  $sumo_short_arch       = $sumo::params::sumo_short_arch,
+  $accessid              = nil,
+  $accesskey             = nil,
   $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
   $sumo_json_source_path = $sumo::params::sumo_json_source_path
 ) inherits sumo::params {
   if $osfamily == 'windows'{
-      class { 'sumo::win_config':
-  	    sumo_conf_source_path => $sumo_conf_source_path,
-  	    sumo_json_source_path => $sumo_json_source_path,
-        accessid => $accessid,
-        accessKey => $accesskey
-  	}
-  }else{
+    class { 'sumo::win_config':
+      sumo_conf_source_path => $sumo_conf_source_path,
+      sumo_json_source_path => $sumo_json_source_path,
+      accessid              => $accessid,
+      accessKey             => $accesskey
+    }
+  } else {
     class { 'sumo::nix_config':
       sumo_conf_source_path => $sumo_conf_source_path,
       sumo_json_source_path => $sumo_json_source_path,
-      accessid => $accessid,
-      accessKey => $accesskey
+      accessid              => $accessid,
+      accessKey             => $accesskey
     }
 
   }

--- a/sumo/manifests/nix_config.pp
+++ b/sumo/manifests/nix_config.pp
@@ -1,3 +1,4 @@
+# Class for sumologic nix config
 class sumo::nix_config (
   $sumo_exec       = $sumo::params::sumo_exec,
   $sumo_short_arch = $sumo::params::sumo_short_arch,

--- a/sumo/manifests/params.pp
+++ b/sumo/manifests/params.pp
@@ -1,10 +1,11 @@
+# Shared params class
 class sumo::params {
-  if ($osfamily == 'windows'){
-    $sumo_conf_source_path = "puppet:///modules/sumo/sumo_win.conf"
-    $sumo_json_source_path = "puppet:///modules/sumo/sumo.json"
-  }else{
-    $sumo_conf_source_path = "puppet:///modules/sumo/sumo_nix.conf"
-    $sumo_json_source_path = "puppet:///modules/sumo/sumo.json"
+  if ($::osfamily == 'windows') {
+    $sumo_conf_source_path = 'puppet:///modules/sumo/sumo_win.conf'
+    $sumo_json_source_path = 'puppet:///modules/sumo/sumo.json'
+  } else {
+    $sumo_conf_source_path = 'puppet:///modules/sumo/sumo_nix.conf'
+    $sumo_json_source_path = 'puppet:///modules/sumo/sumo.json'
     case $::architecture {
       'x86_64': {
         $sumo_exec       = 'sumo64.sh'

--- a/sumo/manifests/win_config.pp
+++ b/sumo/manifests/win_config.pp
@@ -1,3 +1,4 @@
+# class for sumologic windows config
 class sumo::win_config (
   $sumo_exec       = $sumo::params::sumo_exec,
   $sumo_short_arch = $sumo::params::sumo_short_arch,
@@ -11,49 +12,49 @@ class sumo::win_config (
     'c:/sumo/download_sumo.ps1':
       ensure  => present,
       mode    => '0777',
-      group  => 'Administrators',
-      source  => "puppet:///modules/sumo/download_sumo.ps1",
+      group   => 'Administrators',
+      source  => 'puppet:///modules/sumo/download_sumo.ps1',
       require => File['c:/sumo/'];
-      'c:/sumo/':
+    'c:/sumo/':
       ensure => directory,
-      mode => '0777',
-      group => 'Administrators';
-     'c:/sumo/sumo.json':
-       ensure  => present,
-       mode    => '0644',
-       group  => 'Administrators',
-       source  => $sumo_json_source_path,
-       require => File['c:/sumo/'];
-   }
-   exec { 'download_sumo':
-     command => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -executionpolicy remotesigned -file C:\\sumo\\download_sumo.ps1',
-     require => File['c:/sumo/download_sumo.ps1'],
-     creates=>'C:/sumo/sumo.exe'
-     # path => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-     # refreshonly => true,
-   }
-   if ($accessid != nil) and ($accesskey != nil){
-     file{'c:/sumo/sumo.conf':
-       ensure => present,
-       mode   => '0644',
-       group  => 'Administrators',
-       content => template('sumo/sumo.conf.erb'),
-       before => Package['sumologic'];
-     }
-   }
-   else{
-     file{'c:/sumo/sumo.conf':
-       ensure => present,
-       mode   => '0644',
-       group  => 'Administrators',
-       source => $sumo_conf_source_path,
-       before => Package['sumologic'];
-     }
-   }
-   package { 'sumologic':
-     ensure => installed,
-     install_options=>['-q'],
-     source=>'C:/sumo/sumo.exe',
-     require => Exec['download_sumo']
-   }
+      mode   =>  '0777',
+      group  => 'Administrators';
+    'c:/sumo/sumo.json':
+      ensure  => present,
+      mode    => '0644',
+      group   => 'Administrators',
+      source  => $sumo_json_source_path,
+      require => File['c:/sumo/'];
+  }
+  exec { 'download_sumo':
+    command => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -executionpolicy remotesigned -file C:\\sumo\\download_sumo.ps1',
+    require => File['c:/sumo/download_sumo.ps1'],
+    creates => 'C:/sumo/sumo.exe'
+    # path => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+    # refreshonly => true,
+    }
+    if ($accessid != nil) and ($accesskey != nil){
+      file{ 'c:/sumo/sumo.conf':
+        ensure  => present,
+        mode    => '0644',
+        group   => 'Administrators',
+        content => template('sumo/sumo.conf.erb'),
+        before  => Package['sumologic'];
+      }
+    }
+    else {
+      file { 'c:/sumo/sumo.conf':
+        ensure => present,
+        mode   => '0644',
+        group  => 'Administrators',
+        source => $sumo_conf_source_path,
+        before => Package['sumologic'];
+      }
+    }
+    package { 'sumologic':
+      ensure          => installed,
+      install_options => ['-q'],
+      source          => 'C:/sumo/sumo.exe',
+      require         => Exec['download_sumo']
+    }
 }


### PR DESCRIPTION
With the exception of a couple cases of inheritance, and a couple cases
of commands being longer that 80 characters, this gets this module
passing puppet-lint, and just generally tidies it up.