### PR TITLE
Introduce rspec-puppet and compile test for each class

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    sumo: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+group :test do
+  gem 'puppet'
+  gem 'puppetlabs_spec_helper'
+  gem 'rspec-puppet'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,52 @@
+GEM
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.2.5)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    hiera (3.0.6)
+      json_pure
+    json_pure (1.8.3)
+    metaclass (0.0.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    puppet (4.3.2)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure
+    puppet-lint (1.1.0)
+    puppet-syntax (2.1.0)
+      rake
+    puppetlabs_spec_helper (1.1.1)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    rake (10.5.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-puppet (2.3.2)
+      rspec
+    rspec-support (3.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puppet
+  puppetlabs_spec_helper
+  rspec-puppet
+
+BUNDLED WITH
+   1.11.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,14 +12,14 @@ class sumo (
       sumo_conf_source_path => $sumo_conf_source_path,
       sumo_json_source_path => $sumo_json_source_path,
       accessid              => $accessid,
-      accessKey             => $accesskey
+      accesskey             => $accesskey
     }
   } else {
     class { 'sumo::nix_config':
       sumo_conf_source_path => $sumo_conf_source_path,
       sumo_json_source_path => $sumo_json_source_path,
       accessid              => $accessid,
-      accessKey             => $accesskey
+      accesskey             => $accesskey
     }
 
   }

--- a/manifests/nix_config.pp
+++ b/manifests/nix_config.pp
@@ -1,12 +1,12 @@
 # Class for sumologic nix config
 class sumo::nix_config (
-  $sumo_exec       = $sumo::params::sumo_exec,
-  $sumo_short_arch = $sumo::params::sumo_short_arch,
-  $accessid        = $sumo::accessid,
-  $accesskey       = $sumo::accesskey,
+  $sumo_exec             = $sumo::params::sumo_exec,
+  $sumo_short_arch       = $sumo::params::sumo_short_arch,
+  $accessid              = $sumo::accessid,
+  $accesskey             = $sumo::accesskey,
   $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
   $sumo_json_source_path = $sumo::params::sumo_json_source_path,
-  $sources_disk_path = '/usr/local/sumo/sumo.json'
+  $sources_disk_path     = '/usr/local/sumo/sumo.json'
 ) inherits sumo::params {
   file {
     '/usr/local/sumo':

--- a/manifests/win_config.pp
+++ b/manifests/win_config.pp
@@ -1,40 +1,40 @@
 # class for sumologic windows config
 class sumo::win_config (
-  $sumo_exec       = $sumo::params::sumo_exec,
-  $sumo_short_arch = $sumo::params::sumo_short_arch,
-  $accessid        = $sumo::accessid,
-  $accesskey       = $sumo::accesskey,
+  $sumo_exec             = $sumo::params::sumo_exec,
+  $sumo_short_arch       = $sumo::params::sumo_short_arch,
+  $accessid              = $sumo::accessid,
+  $accesskey             = $sumo::accesskey,
   $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
   $sumo_json_source_path = $sumo::params::sumo_json_source_path,
-  $sources_disk_path = 'c:/sumo/sumo.json'
+  $sources_disk_path     = 'C:\sumo\sumo.json'
 ) inherits sumo::params {
   file {
-    'c:/sumo/download_sumo.ps1':
+    'C:\sumo\download_sumo.ps1':
       ensure  => present,
       mode    => '0777',
       group   => 'Administrators',
       source  => 'puppet:///modules/sumo/download_sumo.ps1',
-      require => File['c:/sumo/'];
-    'c:/sumo/':
+      require => File['C:\sumo'];
+    'C:\sumo':
       ensure => directory,
       mode   =>  '0777',
       group  => 'Administrators';
-    'c:/sumo/sumo.json':
+    'C:\sumo\sumo.json':
       ensure  => present,
       mode    => '0644',
       group   => 'Administrators',
       source  => $sumo_json_source_path,
-      require => File['c:/sumo/'];
+      require => File['C:\sumo'];
   }
   exec { 'download_sumo':
     command => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -executionpolicy remotesigned -file C:\\sumo\\download_sumo.ps1',
-    require => File['c:/sumo/download_sumo.ps1'],
-    creates => 'C:/sumo/sumo.exe'
+    require => File['C:\sumo\download_sumo.ps1'],
+    creates => 'C:\sumo\sumo.exe'
     # path => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
     # refreshonly => true,
     }
     if ($accessid != nil) and ($accesskey != nil){
-      file{ 'c:/sumo/sumo.conf':
+      file { 'C:\sumo\sumo.conf':
         ensure  => present,
         mode    => '0644',
         group   => 'Administrators',
@@ -54,7 +54,7 @@ class sumo::win_config (
     package { 'sumologic':
       ensure          => installed,
       install_options => ['-q'],
-      source          => 'C:/sumo/sumo.exe',
+      source          => 'C:\sumo\sumo.exe',
       require         => Exec['download_sumo']
     }
 }

--- a/spec/classes/sumo/nix_config_spec.rb
+++ b/spec/classes/sumo/nix_config_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe 'sumo::nix_config' do
+  let(:facts) { { architecture: 'x86_64' } }
+
+  it { is_expected.to compile }
+end

--- a/spec/classes/sumo/params_spec.rb
+++ b/spec/classes/sumo/params_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe 'sumo::params' do
+  let(:facts) { { architecture: 'x86_64' } }
+
+  it { is_expected.to compile }
+end

--- a/spec/classes/sumo/win_config_spec.rb
+++ b/spec/classes/sumo/win_config_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe 'sumo::win_config' do
+  let(:facts) { { architecture: 'x86_64', kernel: 'windows' } }
+
+  it { is_expected.to compile }
+end

--- a/spec/classes/sumo_spec.rb
+++ b/spec/classes/sumo_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe 'sumo' do
+  let(:facts) { { osfamily: 'Debian', architecture: 'x86_64' } }
+
+  it { is_expected.to compile }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,30 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  c.before :each do
+    # Change autosign from being posix path, which breaks Puppet when we're pretending to be on Windows
+    Puppet[:autosign] = true
+
+    # Work even if you don't specify facts
+    f = self.respond_to?(:facts) ? facts : {}
+    # Automatically detect whether we're pretending to run on Windows
+    Thread.current[:windows?] = lambda { f[:kernel] == "windows" }
+  end
+end
+
+module Puppet
+  module Util
+    module Platform
+      def self.windows?
+        # This is where Puppet normally looks for the target OS.
+        # It normally returns the *current* OS (i.e., not Windows,
+        # if you're not running the specs on Windows)
+        if Thread.current[:windows?]
+          !!Thread.current[:windows?].call
+        else
+          false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the setup for rspec-puppet unit tests to the module, and
adds a very simple "does the manifest compile" test for each class. I
wanted to add all the setup in a separate PR so that it didn't get too
bloated.

Puppet/rspec-puppet seem to have a fun bug revolving around Windows file
paths in which Puppet won't correctly detect what kernel you're
intending, and will complain that the Windows file path (which doesn't
start with a `/`) is unqualified. I included a workaround in
spec_helper.rb from a rspec-puppet thread about the issue.

https://github.com/rodjek/rspec-puppet/issues/192

Furthermore, a couple params weren't being passed properly to the
*_config.pp classes, so I fixed those as well so the module can compile.

@duchatran We should get this running on CI as well, but I'll let you handle that.