### PR TITLE
Add a metadata.json file

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,12 @@
+{
+  "name": "sumo",
+  "version": "0.1.0",
+  "author": "SumoLogic",
+  "summary": "Provides SumoLogic collector installation and configuration",
+  "license": "Apache-2.0",
+  "source": "https://github.com/SumoLogic/sumo-collector-puppet-module",
+  "project_page": "https://github.com/SumoLogic/sumo-collector-puppet-module",
+  "issues_url": "https://github.com/SumoLogic/sumo-collector-puppet-module/issues",
+  "dependencies": [],
+  "requirements": [],
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "sumo",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "author": "SumoLogic",
   "summary": "Provides SumoLogic collector installation and configuration",
   "license": "Apache-2.0",
@@ -8,5 +8,5 @@
   "project_page": "https://github.com/SumoLogic/sumo-collector-puppet-module",
   "issues_url": "https://github.com/SumoLogic/sumo-collector-puppet-module/issues",
   "dependencies": [],
-  "requirements": [],
+  "requirements": []
 }


### PR DESCRIPTION
This is what most puppet package managers (Puppet Forge, Librarian
Puppet) use to populate metadata about your module. And if you don't
have it, they spit out fun little warnings like:
```text
Module git@github.com:SumoLogic/sumo-collector-puppet-module.git#master
does not have version, defaulting to 0.0.1
```

I defaulted the module to version 0.1.0, with the Apache-2.0 license,
which is what it looks like you're using. Let me know if you have any
issues with that.

/cc @duchatran