### PR TITLE
Make most configuration options available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+spec/fixtures

--- a/README.md
+++ b/README.md
@@ -1,19 +1,46 @@
 sumo-collector-puppet-module
 ============================
 
-Puppet module for installing Sumo Logic's collector. This downloads the sumo logic agent from the Internet, so Internet access is required on your machines.
+Puppet module for installing Sumo Logic's collector. This downloads the sumo
+logic agent from the Internet, so Internet access is required on your machines.
 
+## Usage
+```Puppet
+class { 'sumo':
+  accessid       => 'accessid',
+  accesskey      => 'accesskey',
+  manage_sources => false,
+}
+```
 
+## Parameters
+This module supports almost all of the configuration options listed in
+SumoLogic's documentation,
+http://help.sumologic.com/Send_Data/Installed_Collectors/sumo.conf.  Head there
+for a full explanation of what each option does to the SumoLogic collector.
 
-## The Files in the files directory are stubs for the json and config if the conf file is not filled out on windows it will not install properly.
+The only required parameters are a pair of authentication parameters: either
+accessid and accesskey, or email and password.
 
-
-## Usage  
-
-include sumo
-
-
-## optional variables
-
-`$sumo_conf_source_path` - source path to the .conf file which contains access/secret key
-`$sumo_json_source_path` - source path to the .json file to configure sources
+| Parameter Name        | Description                                            | Default value (in the module, not the collector)
+|-----------------------|--------------------------------------------------------|-------------------------------------------------
+| accessid              | The access id for the collector to register with       | undef
+| accesskey             | The access key for the collector to register with      | undef
+| clobber               | Whether you want to clobber the collector              | false
+| collector_name        | Name of the collector                                  | undef
+| email                 | The email for the collector to register with           | undef
+| password              | The password for the collector to register with        | undef
+| ephemeral             | Whether to mark the collector as ephemeral             | false
+| manage_config_file    | If you want this module to manage your sumo.conf file  | true
+| manage_sources        | If you want this module to manage your sources file    | false
+| proxy_host            | When using a proxy, the hostname to connect to         | undef
+| proxy_ntlmdomain      | When using an NTML proxy, the URL used to connect      | undef
+| proxy_password        | When using a proxy, the password to use to connect     | undef
+| proxy_port            | When using a proxy, the port to connect to             | undef
+| proxy_user            | When using a proxy, the user to connect as             | undef
+| sources               | The destination (on disk) of your sources file         | platform specific
+| sumo_conf_source_path | The Puppet URL for your sumo.conf file                 | platform specific
+| sumo_json_source_path | The Puppet URL for your sumo.json file                 | puppet:///modules/sumo/sumo.json
+| sumo_exec             | The installation executable name                       | architecture specific
+| sumo_short_arch       | The shortened architecture to download                 | architecture specific
+| syncsources           | For Local File Configuration, the sources file to sync | $sources

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,27 +1,29 @@
 # The official SumoLogic collector puppet module
 class sumo (
+  $accessid              = undef,
+  $accesskey             = undef,
+  $clobber               = false,
+  $collector_name        = undef,
+  $email                 = undef,
+  $ephemeral             = false,
+  $manage_config_file    = true,
+  $manage_sources        = false,
+  $password              = undef,
+  $proxy_host            = undef,
+  $proxy_ntlmdomain      = undef,
+  $proxy_password        = undef,
+  $proxy_port            = undef,
+  $proxy_user            = undef,
+  $sources               = $sumo::params::sources,
+  $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
+  $sumo_json_source_path = $sumo::params::sumo_json_source_path,
   $sumo_exec             = $sumo::params::sumo_exec,
   $sumo_short_arch       = $sumo::params::sumo_short_arch,
-  $accessid              = nil,
-  $accesskey             = nil,
-  $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
-  $sumo_json_source_path = $sumo::params::sumo_json_source_path
+  $syncsources           = $sumo::params::syncsources,
 ) inherits sumo::params {
   if $osfamily == 'windows'{
-    class { 'sumo::win_config':
-      sumo_conf_source_path => $sumo_conf_source_path,
-      sumo_json_source_path => $sumo_json_source_path,
-      accessid              => $accessid,
-      accesskey             => $accesskey
-    }
+    class { 'sumo::win_config': }
   } else {
-    class { 'sumo::nix_config':
-      sumo_conf_source_path => $sumo_conf_source_path,
-      sumo_json_source_path => $sumo_json_source_path,
-      accessid              => $accessid,
-      accesskey             => $accesskey
-    }
-
+    class { 'sumo::nix_config': }
   }
-
 }

--- a/manifests/nix_config.pp
+++ b/manifests/nix_config.pp
@@ -1,52 +1,61 @@
 # Class for sumologic nix config
 class sumo::nix_config (
-  $sumo_exec             = $sumo::params::sumo_exec,
-  $sumo_short_arch       = $sumo::params::sumo_short_arch,
-  $accessid              = $sumo::accessid,
-  $accesskey             = $sumo::accesskey,
-  $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
-  $sumo_json_source_path = $sumo::params::sumo_json_source_path,
-  $sources_disk_path     = '/usr/local/sumo/sumo.json'
-) inherits sumo::params {
-  file {
-    '/usr/local/sumo':
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 'root';
-    '/usr/local/sumo/sumo.json':
+  $accessid               = $sumo::accessid,
+  $accesskey              = $sumo::accesskey,
+  $clobber                = $sumo::clobber,
+  $collector_name         = $sumo::collector_name,
+  $email                  = $sumo::email,
+  $ephemeral              = $sumo::ephemeral,
+  $manage_config_file     = $sumo::manage_config_file,
+  $manage_sources         = $sumo::manage_sources,
+  $password               = $sumo::password,
+  $proxy_host             = $sumo::proxy_host,
+  $proxy_ntlmdomain       = $sumo::proxy_ntlmdomain,
+  $proxy_password         = $sumo::proxy_password,
+  $proxy_port             = $sumo::proxy_port,
+  $proxy_user             = $sumo::proxy_user,
+  $sources                = $sumo::sources,
+  $sumo_conf_source_path  = $sumo::sumo_conf_source_path,
+  $sumo_exec              = $sumo::sumo_exec,
+  $sumo_short_arch        = $sumo::sumo_short_arch,
+  $syncsources            = $sumo::syncsources,
+) {
+  unless ($accessid != undef and $accesskey != undef) or ($email != undef and $password != undef) {
+    fail(
+      'You must provide either an accesskey and accessid, or an email and password for the SumoLogic collector to connect with.'
+    )
+  }
+
+  file { '/usr/local/sumo':
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+  }
+
+  if $manage_sources {
+    file { '/usr/local/sumo/sumo.json':
       ensure  => present,
       owner   => 'root',
       mode    => '0600',
       group   => 'root',
       source  => $sumo_json_source_path,
-      require => File['/usr/local/sumo'];
-  }
-  if ($accessid != nil) and ($accesskey != nil) {
-      file {
-          '/etc/sumo.conf':
-            ensure => present,
-            owner  => root,
-            mode   => '0600',
-            group  => root,
-            content => template('sumo/sumo.conf.erb');
-        }
-  }
-  else{
-      file {
-          '/etc/sumo.conf':
-            ensure => present,
-            owner  => root,
-            mode   => '0600',
-            group  => root,
-            source => $sumo_conf_source_path;
-        }
+      require => File['/usr/local/sumo']
+    }
   }
 
+  if $manage_config_file {
+    file { '/etc/sumo.conf':
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+      content => template('sumo/sumo.conf.erb')
+    }
+  }
 
   exec { 'Download Sumo Executable':
     command => "/usr/bin/curl -o /usr/local/sumo/${sumo_exec} https://collectors.sumologic.com/rest/download/linux/${sumo_short_arch}",
     cwd     => '/usr/bin',
-    path    => [ '/usr/bin', '/usr/local/bin' ],
     creates => "/usr/local/sumo/${sumo_exec}",
     require => File['/usr/local/sumo'],
   }
@@ -55,7 +64,6 @@ class sumo::nix_config (
     command => "/bin/sh /usr/local/sumo/${sumo_exec} -q",
     cwd     => '/usr/local/sumo',
     creates => '/opt/SumoCollector',
-    path    => ['/usr/local/sumo', '/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     require => Exec['Download Sumo Executable'],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,17 +1,13 @@
 # Shared params class
 class sumo::params {
   if ($::osfamily == 'windows') {
-    $sumo_conf_source_path = 'puppet:///modules/sumo/sumo_win.conf'
-    $sumo_json_source_path = 'puppet:///modules/sumo/sumo.json'
+    $sumo_conf_source_path  = 'puppet:///modules/sumo/sumo_win.conf'
+    $sources = 'C:\sumo\sumo.json'
   } else {
-    $sumo_conf_source_path = 'puppet:///modules/sumo/sumo_nix.conf'
-    $sumo_json_source_path = 'puppet:///modules/sumo/sumo.json'
+    $sumo_conf_source_path  = 'puppet:///modules/sumo/sumo_nix.conf'
+    $sources = '/usr/local/sumo/sumo.json'
     case $::architecture {
-      'x86_64': {
-        $sumo_exec       = 'sumo64.sh'
-        $sumo_short_arch = '64'
-      }
-      'amd64': {
+      'x86_64', 'amd64': {
         $sumo_exec       = 'sumo64.sh'
         $sumo_short_arch = '64'
       }
@@ -20,8 +16,9 @@ class sumo::params {
         $sumo_short_arch = '32'
       }
       default: { fail("there is no supported arch ${::architecture}") }
-
     }
   }
 
+  $sumo_json_source_path = 'puppet:///modules/sumo/sumo.json'
+  $syncsources           = $sources
 }

--- a/spec/classes/sumo/nix_config_spec.rb
+++ b/spec/classes/sumo/nix_config_spec.rb
@@ -3,5 +3,41 @@ require 'spec_helper'
 RSpec.describe 'sumo::nix_config' do
   let(:facts) { { architecture: 'x86_64' } }
 
+  context 'with manage_sources false' do
+    let(:params) { { manage_sources: false, accessid: 'accessid', accesskey: 'accesskey' } }
+    it { is_expected.not_to contain_file('/usr/local/sumo/sumo.json') }
+  end
+
+  context 'with manage_config_file false' do
+    let(:params) { { manage_config_file: false, accessid: 'accessid', accesskey: 'accesskey' } }
+    it { is_expected.not_to contain_file('/etc/sumo.conf') }
+  end
+
+  context 'with only email and password' do
+    let(:params) { { email: 'email', password: 'password' } }
+    it { is_expected.to compile }
+  end
+
+  context 'with no accessid/accesskey or email/password' do
+    let(:params) { { } }
+    it { is_expected.to compile.and_raise_error(/You must provide/) }
+  end
+
+  let(:params) do
+    {
+      manage_sources: true,
+      manage_config_file: true,
+      accessid: 'accessid',
+      accesskey: 'accesskey',
+    }
+  end
+
   it { is_expected.to compile }
+
+  it { is_expected.to contain_file('/usr/local/sumo') }
+  it { is_expected.to contain_file('/usr/local/sumo/sumo.json') }
+  it { is_expected.to contain_file('/etc/sumo.conf') }
+
+  it { is_expected.to contain_exec('Download Sumo Executable') }
+  it { is_expected.to contain_exec('Execute sumo') }
 end

--- a/spec/classes/sumo/params_spec.rb
+++ b/spec/classes/sumo/params_spec.rb
@@ -4,4 +4,9 @@ RSpec.describe 'sumo::params' do
   let(:facts) { { architecture: 'x86_64' } }
 
   it { is_expected.to compile }
+
+  context 'with an invalid architecture' do
+    let(:facts) { { architecture: 'i386' } }
+    it { is_expected.to compile.and_raise_error(/there is no supported arch/) }
+  end
 end

--- a/spec/classes/sumo/win_config_spec.rb
+++ b/spec/classes/sumo/win_config_spec.rb
@@ -3,5 +3,32 @@ require 'spec_helper'
 RSpec.describe 'sumo::win_config' do
   let(:facts) { { architecture: 'x86_64', kernel: 'windows' } }
 
+  context 'with manage_sources false' do
+    let(:params) { { manage_sources: false, accessid: 'accessid', accesskey: 'accesskey' } }
+    it { is_expected.not_to contain_file('C:\sumo\sumo.json') }
+  end
+
+  context 'with manage_config_file false' do
+    let(:params) { { manage_config_file: false, accessid: 'accessid', accesskey: 'accesskey' } }
+    it { is_expected.not_to contain_file('C:\sumo\sumo.conf') }
+  end
+
+  let(:params) do
+    {
+      manage_sources: true,
+      manage_config_file: true,
+      accessid: 'accessid',
+      accesskey: 'accesskey',
+    }
+  end
+
   it { is_expected.to compile }
+
+  it { is_expected.to contain_file('C:\sumo\download_sumo.ps1') }
+  it { is_expected.to contain_file('C:\sumo') }
+  it { is_expected.to contain_file('C:\sumo\sumo.json') }
+  it { is_expected.to contain_file('C:\sumo\sumo.conf') }
+
+  it { is_expected.to contain_exec('download_sumo') }
+  it { is_expected.to contain_package('sumologic') }
 end

--- a/spec/classes/sumo_spec.rb
+++ b/spec/classes/sumo_spec.rb
@@ -2,6 +2,21 @@ require 'spec_helper'
 
 RSpec.describe 'sumo' do
   let(:facts) { { osfamily: 'Debian', architecture: 'x86_64' } }
+  let(:params) do
+    {
+      accessid: 'accessid',
+      accesskey: 'accesskey'
+    }
+  end
 
   it { is_expected.to compile }
+
+  context 'on a window machine' do
+    let(:facts) { { osfamily: 'windows', architecture: 'x86_64' } }
+    it { is_expected.to contain_class('sumo::win_config') }
+  end
+
+  context 'on a *nix machine' do
+    it { is_expected.to contain_class('sumo::nix_config') }
+  end
 end

--- a/templates/sumo.conf.erb
+++ b/templates/sumo.conf.erb
@@ -1,4 +1,51 @@
+# This file is managed by Puppet
+
+<% if @accessid && @accesskey %>
 accessid=<%= @accessid %>
 accesskey=<%= @accesskey %>
-ephemeral=true
-sources=<%= @sources_disk_path %>
+<% end %>
+
+<% if @email && @password %>
+email=<%= @email %>
+password=<%= @password %>
+<% end %>
+
+<% if @collector_name %>
+name=<%= @collector_name %>
+<% end %>
+
+<% if @sources %>
+sources=<%= @sources %>
+<% end %>
+
+<% if @ephemeral %>
+ephemeral=<%= @ephemeral %>
+<% end %>
+
+<% if @clobber %>
+clobber=<%= @clobber %>
+<% end %>
+
+<% if @proxy_host %>
+proxyHost=<%= @proxy_host %>
+<% end %>
+
+<% if @proxy_port %>
+proxyPort=<%= @proxy_port %>
+<% end %>
+
+<% if @proxy_user %>
+proxyUser=<%= @proxy_user %>
+<% end %>
+
+<% if @proxy_password %>
+proxyPassword=<%= @proxy_password %>
+<% end %>
+
+<% if @proxy_ntlmdomain %>
+proxyNtlmdomain=<%= @proxy_ntlmdomain %>
+<% end %>
+
+<% if @syncsources %>
+syncSources=<%= @syncsources %>
+<% end %>


### PR DESCRIPTION
This PR does a few things:
* Make most of the collector configuration options outlined in
http://help.sumologic.com/Send_Data/Installed_Collectors/sumo.conf
available.

* Add unit tests around most of the module.

* Flesh out the README to include a valid usage example, and document
all available parameters.

* Require that users pass either an accessid and accesskey, or an email
and password. Otherwise, because we give no hooks into the installation
command, the collector will never be able to connect to the user's
SumoLogic account.