### PR TITLE
Fixed an issue with installing the collector on windows

### DIFF
--- a/manifests/win_config.pp
+++ b/manifests/win_config.pp
@@ -39,7 +39,8 @@ class sumo::win_config (
         mode    => '0644',
         group   => 'Administrators',
         content => template('sumo/sumo.conf.erb'),
-        before  => Package['sumologic'];
+        before  => Package['sumologic'],
+		require => File['C:\sumo'];
       }
     }
     else {
@@ -48,7 +49,8 @@ class sumo::win_config (
         mode   => '0644',
         group  => 'Administrators',
         source => $sumo_conf_source_path,
-        before => Package['sumologic'];
+        before  => Package['sumologic'],
+		require => File['C:\sumo'];
       }
     }
     package { 'sumologic':

--- a/manifests/win_config.pp
+++ b/manifests/win_config.pp
@@ -40,7 +40,7 @@ class sumo::win_config (
         group   => 'Administrators',
         content => template('sumo/sumo.conf.erb'),
         before  => Package['sumologic'],
-		require => File['C:\sumo'];
+        require => File['C:\sumo'];
       }
     }
     else {
@@ -50,7 +50,7 @@ class sumo::win_config (
         group  => 'Administrators',
         source => $sumo_conf_source_path,
         before  => Package['sumologic'],
-		require => File['C:\sumo'];
+        require => File['C:\sumo'];
       }
     }
     package { 'sumologic':


### PR DESCRIPTION
If c:/sumo directory does not exist sumo install fails because sumo.conf file cannot be copied.
Made sure that C:/sumo directory exists before copying sumo.conf file.