### PR TITLE
fix reference to $sumo_json_source_path

### DIFF
--- a/manifests/nix_config.pp
+++ b/manifests/nix_config.pp
@@ -38,7 +38,7 @@ class sumo::nix_config (
       owner   => 'root',
       mode    => '0600',
       group   => 'root',
-      source  => $sumo_json_source_path,
+      source  => $::sumo::params::sumo_json_source_path,
       require => File['/usr/local/sumo']
     }
   }


### PR DESCRIPTION
With usage like this:
```
class { 'sumo':
    accessid           => 'REDACTED',
    accesskey          => 'REDACTED',
    manage_sources     => true,
    manage_config_file => true,
}
```

Prior to fixing:
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Unknown variable: 'sumo_json_source_path'. at /etc/puppetlabs/code/environments/production/modules/sumo/manifests/nix_config.pp:41:18 on node puppet
```

After fixing:
```
Notice: /Stage[main]/Sumo::Nix_config/File[/usr/local/sumo]/ensure: created
Notice: /Stage[main]/Sumo::Nix_config/File[/usr/local/sumo/sumo.json]/ensure: defined content as '{md5}304694fe3fd0b96e91dc8dcab2b5e8e8'
Notice: /Stage[main]/Sumo::Nix_config/File[/etc/sumo.conf]/ensure: defined content as '{md5}db80e902cf1f591b844e348f33dc4b2d'
Notice: /Stage[main]/Sumo::Nix_config/Exec[Download Sumo Executable]/returns: executed successfully
Notice: /Stage[main]/Sumo::Nix_config/Exec[Execute sumo]/returns: executed successfully
Notice: Applied catalog in 39.79 seconds
```