### PR TITLE
Support sumo.json content parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ for a full explanation of what each option does to the SumoLogic collector.
 The only required parameters are a pair of authentication parameters: either
 `accessid` and `accesskey`, or `email` and `password`.
 
+If `manage_sources` is True, either `sumo_json_content` or `sumo_json_source_path` should be defined (but not both).
+
 | Parameter Name        | Description                                            | Default value (in the module, not the collector)
 |-----------------------|--------------------------------------------------------|-------------------------------------------------
 | accessid              | The access id for the collector to register with       | undef
@@ -39,6 +41,7 @@ The only required parameters are a pair of authentication parameters: either
 | proxy_user            | When using a proxy, the user to connect as             | undef
 | sources               | The destination (on disk) of your sources file         | platform specific
 | sumo_conf_source_path | The Puppet URL for your sumo.conf file                 | platform specific
+| sumo_json_content     | The text content for your sumo.json file                 | undef
 | sumo_json_source_path | The Puppet URL for your sumo.json file                 | puppet:///modules/sumo/sumo.json
 | sumo_exec             | The installation executable name                       | architecture specific
 | sumo_short_arch       | The shortened architecture to download                 | architecture specific

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,11 +16,21 @@ class sumo (
   $proxy_user            = undef,
   $sources               = $sumo::params::sources,
   $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
-  $sumo_json_source_path = $sumo::params::sumo_json_source_path,
+  $sumo_json_source_path = undef,
+  $sumo_json_content     = undef,
   $sumo_exec             = $sumo::params::sumo_exec,
   $sumo_short_arch       = $sumo::params::sumo_short_arch,
   $syncsources           = $sumo::params::syncsources,
 ) inherits sumo::params {
+   if $manage_sources {
+     if $sumo_json_source_path == undef and $sumo_json_content == undef {
+       $sumo_json_source_path = $sumo::params::sumo_json_source_path
+    }
+    unless ($sumo_json_source_path != undef and $sumo_json_content == undef) or ($sumo_json_source_path == undef and $sumo_json_content != undef) {
+      fail("You must define exactly one of sumo_json_source_path or sumo_json_content. ${sumo_json_source_path} ${sumo_json_content}")
+    }
+  }
+
   if $::osfamily == 'windows'{
     class { 'sumo::win_config': }
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,17 +16,14 @@ class sumo (
   $proxy_user            = undef,
   $sources               = $sumo::params::sources,
   $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
-  $sumo_json_source_path = undef,
+  $sumo_json_source_path = $sumo::params::sumo_json_source_path,
   $sumo_json_content     = undef,
   $sumo_exec             = $sumo::params::sumo_exec,
   $sumo_short_arch       = $sumo::params::sumo_short_arch,
   $syncsources           = $sumo::params::syncsources,
 ) inherits sumo::params {
    if $manage_sources {
-     if $sumo_json_source_path == undef and $sumo_json_content == undef {
-       $sumo_json_source_path = $sumo::params::sumo_json_source_path
-    }
-    unless ($sumo_json_source_path != undef and $sumo_json_content == undef) or ($sumo_json_source_path == undef and $sumo_json_content != undef) {
+    unless ($sumo_json_source_path and ! $sumo_json_content) or (! $sumo_json_source_path and $sumo_json_content) {
       fail("You must define exactly one of sumo_json_source_path or sumo_json_content. ${sumo_json_source_path} ${sumo_json_content}")
     }
   }

--- a/manifests/nix_config.pp
+++ b/manifests/nix_config.pp
@@ -38,6 +38,7 @@ class sumo::nix_config (
       owner   => 'root',
       mode    => '0600',
       group   => 'root',
+      content => $sumo::sumo_json_content,
       source  => $sumo::sumo_json_source_path,
       require => File['/usr/local/sumo']
     }

--- a/manifests/win_config.pp
+++ b/manifests/win_config.pp
@@ -45,6 +45,7 @@ class sumo::win_config (
       ensure  => present,
       mode    => '0644',
       group   => 'Administrators',
+      content => $sumo::sumo_json_content,
       source  => $sumo::sumo_json_source_path,
       require => File['C:\sumo'],
     }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -5,8 +5,8 @@ describe 'sumo class: management of sources/config' do
   it 'should work idempotently with no errors' do
     pp = <<-EOS
     class { 'sumo':
-      accessid           => 'sue4YBD9gAlqew',
-      accesskey          => 'YIwGHyE6O9bTkdGMLenuVMZ9Ifbbl55GxsjZxHXSr1ZeHDeGqSXZqAd82yrq8M0p',
+      accessid           => 'XXXX: must be filled in to work',
+      accesskey          => 'YYYY: must be filled in to work',
       manage_config_file => true,
       manage_sources     => true,
     }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -5,8 +5,8 @@ describe 'sumo class: management of sources/config' do
   it 'should work idempotently with no errors' do
     pp = <<-EOS
     class { 'sumo':
-      accessid           => 'XXXX: must be filled in to work',
-      accesskey          => 'YYYY: must be filled in to work',
+      accessid           => 'sue4YBD9gAlqew',
+      accesskey          => 'YIwGHyE6O9bTkdGMLenuVMZ9Ifbbl55GxsjZxHXSr1ZeHDeGqSXZqAd82yrq8M0p',
       manage_config_file => true,
       manage_sources     => true,
     }

--- a/spec/classes/sumo/nix_config_spec.rb
+++ b/spec/classes/sumo/nix_config_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'sumo::nix_config' do
 
   it { is_expected.to contain_file('/usr/local/sumo') }
   it { is_expected.to contain_file('/usr/local/sumo/sumo.json') }
-  it { is_expected.to contain_file('/etc/sumo.conf') }
+  it { is_expected.to contain_file('/etc/sumo.conf').with_content(/accessid/) }
 
   it { is_expected.to contain_exec('Download Sumo Executable') }
   it { is_expected.to contain_exec('Execute sumo') }

--- a/spec/classes/sumo/win_config_spec.rb
+++ b/spec/classes/sumo/win_config_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe 'sumo::win_config' do
     it { is_expected.not_to contain_file('C:\sumo\sumo.conf') }
   end
 
+  context 'with no accessid/accesskey or email/password' do
+    let(:params) { { } }
+    it { is_expected.to compile.and_raise_error(/You must provide/) }
+  end
+
   let(:params) do
     {
       manage_sources: true,
@@ -27,7 +32,7 @@ RSpec.describe 'sumo::win_config' do
   it { is_expected.to contain_file('C:\sumo\download_sumo.ps1') }
   it { is_expected.to contain_file('C:\sumo') }
   it { is_expected.to contain_file('C:\sumo\sumo.json') }
-  it { is_expected.to contain_file('C:\sumo\sumo.conf') }
+  it { is_expected.to contain_file('C:\sumo\sumo.conf').with_content(/accessid/) }
 
   it { is_expected.to contain_exec('download_sumo') }
   it { is_expected.to contain_package('sumologic') }

--- a/spec/classes/sumo_spec.rb
+++ b/spec/classes/sumo_spec.rb
@@ -19,4 +19,52 @@ RSpec.describe 'sumo' do
   context 'on a *nix machine' do
     it { is_expected.to contain_class('sumo::nix_config') }
   end
+
+  context 'with both json source path and content' do
+    let(:params) {
+      {
+        manage_sources: true,
+        sumo_json_content: 'test',
+        sumo_json_source_path: 'test',
+      }
+    }
+    it { is_expected.to compile.and_raise_error(/You must define exactly one of/) }
+  end
+
+  context 'with json content' do
+    let(:params) {
+      {
+        accessid: 'accessid',
+        accesskey: 'accesskey',
+        manage_sources: true,
+        sumo_json_content: 'test',
+      }
+    }
+    it { is_expected.to contain_file('/usr/local/sumo/sumo.json').with_content('test') }
+  end
+
+  context 'with no sources management' do
+    let(:params) {
+      {
+        accessid: 'accessid',
+        accesskey: 'accesskey',
+        manage_sources: false,
+        sumo_json_content: 'test',
+      }
+    }
+    it { is_expected.to compile }
+  end
+
+  context 'with json content on windows' do
+    let(:facts) { { osfamily: 'windows', architecture: 'x86_64' } }
+    let(:params) {
+      {
+        accessid: 'accessid',
+        accesskey: 'accesskey',
+        manage_sources: true,
+        sumo_json_content: 'test',
+      }
+    }
+    it { is_expected.to contain_file('C:\sumo\sumo.json').with_content('test') }
+  end
 end

--- a/spec/classes/sumo_spec.rb
+++ b/spec/classes/sumo_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'sumo' do
         accesskey: 'accesskey',
         manage_sources: true,
         sumo_json_content: 'test',
+        sumo_json_source_path: false,
       }
     }
     it { is_expected.to contain_file('/usr/local/sumo/sumo.json').with_content('test') }
@@ -63,6 +64,7 @@ RSpec.describe 'sumo' do
         accesskey: 'accesskey',
         manage_sources: true,
         sumo_json_content: 'test',
+        sumo_json_source_path: false,
       }
     }
     it { is_expected.to contain_file('C:\sumo\sumo.json').with_content('test') }


### PR DESCRIPTION
This PR allows the content of sumo.json to be specified directly instead of a Puppet URL in a similar fashion as the file resource.
