### PR TITLE
Allow json sources to be configured

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class sumo (
   $proxy_user            = undef,
   $sources               = $sumo::params::sources,
   $sumo_conf_source_path = $sumo::params::sumo_conf_source_path,
+  $sumo_conf_template_path = $sumo::params::sumo_conf_template_path,
   $sumo_json_source_path = $sumo::params::sumo_json_source_path,
   $sumo_exec             = $sumo::params::sumo_exec,
   $sumo_short_arch       = $sumo::params::sumo_short_arch,

--- a/manifests/nix_config.pp
+++ b/manifests/nix_config.pp
@@ -31,7 +31,7 @@ class sumo::nix_config (
   }
 
   if $manage_sources {
-    file { '/usr/local/sumo/sumo.json':
+    file { $sources:
       ensure  => present,
       owner   => 'root',
       mode    => '0600',
@@ -47,7 +47,7 @@ class sumo::nix_config (
       owner   => 'root',
       group   => 'root',
       mode    => '0600',
-      content => template('sumo/sumo.conf.erb')
+      content => template($sumo::sumo_conf_template_path),
     }
   }
 

--- a/manifests/nix_config.pp
+++ b/manifests/nix_config.pp
@@ -14,6 +14,7 @@ class sumo::nix_config (
   $proxy_user             = $sumo::proxy_user,
   $sources                = $sumo::sources,
   $sumo_conf_source_path  = $sumo::sumo_conf_source_path,
+  $sumo_conf_template_path  = $sumo::sumo_conf_template_path,
   $sumo_exec              = $sumo::sumo_exec,
   $sumo_short_arch        = $sumo::sumo_short_arch,
   $syncsources            = $sumo::syncsources,
@@ -47,7 +48,7 @@ class sumo::nix_config (
       owner   => 'root',
       group   => 'root',
       mode    => '0600',
-      content => template($sumo::sumo_conf_template_path),
+      content => template($sumo_conf_template_path),
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class sumo::params {
     }
   }
 
+  $sumo_conf_template_path = 'sumo/sumo.conf.erb'
   $sumo_json_source_path = 'puppet:///modules/sumo/sumo.json'
   $syncsources           = $sources
 }

--- a/spec/classes/sumo/nix_config_spec.rb
+++ b/spec/classes/sumo/nix_config_spec.rb
@@ -14,7 +14,15 @@ RSpec.describe 'sumo::nix_config' do
   end
 
   context 'with only accessid and accesskey' do
-    let(:params) { { accessid: 'accessid', accesskey: 'accesskey' } }
+    #let(:params) { { accessid: 'accessid', accesskey: 'accesskey' } }
+    let(:params) do
+      {
+        accessid: 'accessid',
+        accesskey: 'accesskey',
+        sumo_conf_template_path: 'sumo/sumo.conf.erb',
+        sources: '/usr/local/sumo/sumo.json',
+      }
+    end
     it { is_expected.to compile }
   end
 
@@ -29,6 +37,8 @@ RSpec.describe 'sumo::nix_config' do
       manage_config_file: true,
       accessid: 'accessid',
       accesskey: 'accesskey',
+      sumo_conf_template_path: 'sumo/sumo.conf.erb',
+      sources: '/usr/local/sumo/sumo.json',
     }
   end
 
@@ -40,4 +50,20 @@ RSpec.describe 'sumo::nix_config' do
 
   it { is_expected.to contain_exec('Download Sumo Executable') }
   it { is_expected.to contain_exec('Execute sumo') }
+
+  context 'with alternate sources location' do
+    let(:params) do
+      { 
+        manage_sources: true,
+        manage_config_file: true,
+        accessid: 'accessid',
+        accesskey: 'accesskey',
+        sumo_conf_template_path: 'sumo/sumo.conf.erb',
+        sources: '/etc/sumo.json',
+      } 
+    end
+    it { is_expected.to compile }
+    it { is_expected.to contain_file('/etc/sumo.conf') }
+    it { is_expected.to contain_file('/etc/sumo.json') }
+  end
 end


### PR DESCRIPTION
Use json source file location supplied in $sumo::sources, not hardcoded path
Allow the json template file to be overridden